### PR TITLE
Fixed loosing Saturday when iterating through weekdays

### DIFF
--- a/RWMRecurrenceRule/RWMRuleScheduler.swift
+++ b/RWMRecurrenceRule/RWMRuleScheduler.swift
@@ -148,10 +148,9 @@ public class RWMRuleScheduler {
                 // If WKST is Monday then index 0=Mon, 1=Tue, 2=Wed, ..., 6=Sun
                 let firstDayOfTheWeek = rule.firstDayOfTheWeek?.rawValue ?? calendar.firstWeekday
                 // Convert the standard 1=Sun,2=Mon,...,7=Sat values into the associated weekday index based on the first day of the week
-                for wd in firstDayOfTheWeek..<(firstDayOfTheWeek + 7) {
-                    if daysOfTheWeek.first(where: { $0 == wd % 7 }) != nil {
-                        weekdays.append(wd - firstDayOfTheWeek)
-                    }
+                weekdays = daysOfTheWeek.map { day in
+                    let index = (day - firstDayOfTheWeek) % 7
+                    return index < 0 ? 7 + index : index
                 }
             } else {
                 sow = start

--- a/RWMRecurrenceRuleTests/RWMWeeklyTests.swift
+++ b/RWMRecurrenceRuleTests/RWMWeeklyTests.swift
@@ -145,4 +145,22 @@ class RWMWeeklyTests: RWMRecurrenceRuleBase {
              "2028-06-06T09:00:00", "2028-06-27T09:00:00", "2029-06-19T09:00:00", "2030-06-11T09:00:00"]
         )
     }
+    
+    func testWeekly12() {
+        // Start 20201006T090000
+        let start = calendar.date(from: DateComponents(year: 2020, month: 10, day: 06, hour: 09, minute: 00))!
+        run(rule: "RRULE:FREQ=WEEKLY;UNTIL=20201031T000000Z;INTERVAL=2;BYDAY=MO,TU,WE,TH,FR,SA", start: start, results:
+            ["2020-10-06T09:00:00", // TU
+             "2020-10-07T09:00:00", // WE
+             "2020-10-08T09:00:00", // TH
+             "2020-10-09T09:00:00", // FR
+             "2020-10-10T09:00:00", // SA
+             "2020-10-19T09:00:00", // SA
+             "2020-10-20T09:00:00", // TU
+             "2020-10-21T09:00:00", // WE
+             "2020-10-22T09:00:00", // TH
+             "2020-10-23T09:00:00", // FR
+             "2020-10-24T09:00:00"] // SA
+        )
+    }
 }


### PR DESCRIPTION
When Saturday is used as weekday specifier, e.g. "BYDAY=MO,TU,WE,TH,FR,SA" it will never be converted into weekday index based on the first day of the week.

Issue fixed.